### PR TITLE
Update Minecraft Wiki links to new domain after fork

### DIFF
--- a/docs/default/usage/block.md
+++ b/docs/default/usage/block.md
@@ -8,7 +8,7 @@ description: Edit block NBT
 
 To understand this page you should see [RtagEditor guide](../../usage/editor/).
 
-For better understand about some tile entity tags it's suggested to visit the [Minecraft wiki page](https://minecraft.fandom.com/wiki/Chunk_format#Block_entity_format).
+For better understand about some tile entity tags it's suggested to visit the [Minecraft wiki page](https://minecraft.wiki/w/Chunk_format#Block_entity_format).
 
 :::
 

--- a/docs/default/usage/entity.md
+++ b/docs/default/usage/entity.md
@@ -8,7 +8,7 @@ description: Edit entity NBT
 
 To understand this page you should see [RtagEditor guide](../../usage/editor/).
 
-For better understand about some entity tags it's suggested to visit the [Minecraft wiki page](https://minecraft.fandom.com/wiki/Entity_format).
+For better understand about some entity tags it's suggested to visit the [Minecraft wiki page](https://minecraft.wiki/w/Entity_format).
 
 :::
 

--- a/docs/default/usage/item.md
+++ b/docs/default/usage/item.md
@@ -8,7 +8,7 @@ description: Edit item NBT
 
 To understand this page you should see [RtagEditor guide](../../usage/editor/).
 
-For better understand about some item tags it's suggested to visit the [Minecraft wiki page](https://minecraft.fandom.com/wiki/Player.dat_format#Item_structure).
+For better understand about some item tags it's suggested to visit the [Minecraft wiki page](https://minecraft.wiki/w/Player.dat_format#Item_structure).
 
 :::
 

--- a/docs/es/usage/block.md
+++ b/docs/es/usage/block.md
@@ -14,7 +14,7 @@ Por ahora el RtagBlock solo puede ser utilizado para editar los tags de "tile en
 
 Para entender esta página primero debes ver [la guía de RtagEditor](../../usage/editor/).
 
-Para entender sobre los tags comunes en las "tile entities" se sugiere visitar la [página de la wiki de Minecraft](https://minecraft.fandom.com/wiki/Chunk_format#Block_entity_format).
+Para entender sobre los tags comunes en las "tile entities" se sugiere visitar la [página de la wiki de Minecraft](https://minecraft.wiki/w/Chunk_format#Block_entity_format).
 
 :::
 

--- a/docs/es/usage/entity.md
+++ b/docs/es/usage/entity.md
@@ -8,7 +8,7 @@ description: Editar el NBT de las entidades
 
 Para entender esta página primero debes ver [la guía de RtagEditor](../../usage/editor/).
 
-Para entender sobre los tags comunes en las entidades se sugiere visitar la [página de la wiki de Minecraft](https://minecraft.fandom.com/wiki/Entity_format).
+Para entender sobre los tags comunes en las entidades se sugiere visitar la [página de la wiki de Minecraft](https://minecraft.wiki/w/Entity_format).
 
 :::
 

--- a/docs/es/usage/item.md
+++ b/docs/es/usage/item.md
@@ -8,7 +8,7 @@ description: Editar el NBT de los items
 
 Para entender esta página primero debes ver [la guía de RtagEditor](../../usage/editor/).
 
-Para entender sobre los tags comunes en los items se sugiere visitar la [página de la wiki de Minecraft](https://minecraft.fandom.com/wiki/Player.dat_format#Item_structure).
+Para entender sobre los tags comunes en los items se sugiere visitar la [página de la wiki de Minecraft](https://minecraft.wiki/w/Player.dat_format#Item_structure).
 
 :::
 

--- a/rtag-item/src/main/java/com/saicone/rtag/util/ItemMaterialTag.java
+++ b/rtag-item/src/main/java/com/saicone/rtag/util/ItemMaterialTag.java
@@ -686,7 +686,7 @@ public enum ItemMaterialTag {
     LIME_WOOL(13, "WOOL:5", 8),
     LINGERING_POTION(9),
     // Removed in 1.9
-    // Information: https://minecraft.fandom.com/wiki/Furnace#Lit_furnace_.22item.22
+    // Information: https://minecraft.wiki/w/Furnace#Lit_furnace_%22item%22
     LIT_FURNACE(8, "BURNING_FURNACE"),
     LLAMA_SPAWN_EGG(13, "SPAWN_EGG=llama", 11, "MONSTER_EGG"),
     LODESTONE(16),


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all the URLs to the new domain: minecraft.wiki